### PR TITLE
[Bugfix/DL-10] - Update controller's response method to return 400 if error instead of 500

### DIFF
--- a/source/laravel-api/app/Common/Controller.php
+++ b/source/laravel-api/app/Common/Controller.php
@@ -16,7 +16,10 @@ abstract class Controller
      */
     protected function response(array $result): JsonResponse
     {
-        $status = $result['status'] == config('constants.STATUS_SUCCESS') ? 200 : 500;
+        $status = $result['status'];
+        if(is_bool($status)) {
+            $status = $status ? 200 : 400;
+        }
         return response()->json($result, $status);
     }
 }

--- a/source/laravel-api/app/Common/Service.php
+++ b/source/laravel-api/app/Common/Service.php
@@ -44,4 +44,12 @@ class Service
         ];
     }
 
+    protected function messageReponseStatus(string $message, int $status): array
+    {
+        return [
+            'message' => $message,
+            'status' => $status
+        ];
+    }
+
 }

--- a/source/laravel-api/app/Http/Controllers/Web/UserController.php
+++ b/source/laravel-api/app/Http/Controllers/Web/UserController.php
@@ -38,7 +38,7 @@ class UserController
         $aryRes = $this->userService->verify($intId);
 
         if ($aryRes['status'] == config('constants.STATUS_FAILED')) {
-            abort(500);
+            abort(422);
         }
 
         return redirect()->intended(

--- a/source/laravel-api/tests/Feature/Api/AdminTest.php
+++ b/source/laravel-api/tests/Feature/Api/AdminTest.php
@@ -49,11 +49,11 @@ class AdminTest extends TestCase
     public function test_admin_login_fail(): void
     {
         $response = $this->postJson('/api/v2/admin/login', [
-            'email' => 'testadmin1@test.com',
+            'email' => 'testadmininvalid@test.com',
             'password' => 'testpassadmin'
         ]);
 
-        $response->assertStatus(500)
+        $response->assertStatus(400)
             ->assertJson([
                 'status' => config('constants.STATUS_FAILED'),
             ]);

--- a/source/laravel-api/tests/Feature/Api/UserTest.php
+++ b/source/laravel-api/tests/Feature/Api/UserTest.php
@@ -90,7 +90,7 @@ class UserTest extends TestCase
         ]);
 
         // Assert
-        $response->assertStatus(500)
+        $response->assertStatus(400)
             ->assertJson([
                 'status' => config('constants.STATUS_FAILED'),
             ]);

--- a/source/laravel-api/tests/Feature/Web/UserTest.php
+++ b/source/laravel-api/tests/Feature/Web/UserTest.php
@@ -49,6 +49,6 @@ class UserTest extends TestCase
         $response = $this->get($verificationUrl);
 
         // Assert
-        $response->assertStatus(500);
+        $response->assertStatus(422);
     }
 }


### PR DESCRIPTION
- Update abstract controller class response method from using 500 to 400 error code
- Create a new method called messageReponseStatus at Service to support message response with an integer status code
- Updated test result from 500 to 422 or 400 for failing test in AdminTest, Api/UserTest and Web/UserTest
- Updated verificationEmail method from 500 to 422