### PR TITLE
[Bugfix/DL-11] - Fatal error occured when fetching slides with per_page URL parameter

### DIFF
--- a/source/laravel-api/app/Http/Controllers/Api/SlideController.php
+++ b/source/laravel-api/app/Http/Controllers/Api/SlideController.php
@@ -62,7 +62,7 @@ class SlideController extends Controller
             $columns,
             $request->getFields(),
             $request->input('page', 1),
-            $request->input('per_page', 10),
+            (int) $request->input('per_page', 10),
             "=",
             $request->getOrder()
         );

--- a/source/laravel-api/tests/Feature/Api/SlideTest.php
+++ b/source/laravel-api/tests/Feature/Api/SlideTest.php
@@ -176,7 +176,7 @@ class SlideTest extends TestCase
             ->assertJsonFragment([
                 'title' => "Test Slide title 111",
                 'title' => "Test Slide title 122",
-                'title' => "Test Slide title 133",
+                'title' => "Test Slide title 133"
             ]);
 
     }
@@ -201,6 +201,31 @@ class SlideTest extends TestCase
                 'title' => "Test Slide title 111",
                 'title' => "Test Slide title 122",
                 'title' => "Test Slide title 133",
+            ]);
+
+    }
+
+    public function test_get_per_page(): void
+    {
+        // Arrange
+        $this->createSlide(111);
+        $this->createSlide(122);
+        $this->createSlide(133);
+        $this->createSlide(222);
+        $this->createSlide(333);
+
+        // Act
+        $response = $this->get("/api/v2/slide/get?per_page=10");
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => config('constants.STATUS_SUCCESS'),
+            ])
+            ->assertJsonFragment([
+                'title' => "Test Slide title 111",
+                'title' => "Test Slide title 122",
+                'title' => "Test Slide title 133",
+                'title' => "Test Slide title 222",
+                'title' => "Test Slide title 333",
             ]);
 
     }


### PR DESCRIPTION
- Cast request input per_page to int in SlideController
- Added test "test_get_per_page" on Api\SlideTest